### PR TITLE
Host underscore support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit "2.3.0-alpha2"
+(defproject http-kit "2.3.0-alpha4-j8-hostunderscore"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"
@@ -21,7 +21,7 @@
   ["-Dclojure.compiler.disable-locals-clearing=true"
    "-Xms1g" "-Xmx1g"] ; Testing https require more memory
 
-  :javac-options ["-source" "1.6" "-target" "1.6" "-g"]
+  :javac-options ["-source" "1.8" "-g"]
   :java-source-paths ["src/java"]
   :test-paths ["test"]
   :jar-exclusions [#"^java.*"] ; exclude the java directory in source path

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -297,7 +297,7 @@ public class HttpClient implements Runnable {
         }
 
         if (uri.getHost() == null) {
-            cb.onThrowable(new IllegalArgumentException("host is null: " + url));
+            cb.onThrowable(new IllegalArgumentException("host is invalid: " + url));
             return;
         }
 

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -42,7 +42,7 @@
               queue-size 20480
               max-body   8388608
               max-ws     4194304
-              max-line   4096
+              max-line   8192
               proxy-protocol :disable
               worker-name-prefix "worker-"}}]]
 

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -289,12 +289,12 @@
 
 (deftest test-uri-len
   (doseq [_ (range 0 50)]
-    (let [path (str "/abc" (subs const-string 0 (rand-int 4000)))
+    (let [path (str "/abc" (subs const-string 0 (rand-int 8000)))
           resp @(client/get (str "http://localhost:4347" path))]
       (is (= 200 (:status resp)))
       (is (= path (-> resp :body read-string :uri)))))
   (doseq [_ (range 0 20)]
-    (let [path (str "/abc" (subs const-string 0 (+ (rand-int 4000) 4096)))
+    (let [path (str "/abc" (subs const-string 0 (+ (rand-int 4000) 8192)))
           resp @(client/get (str "http://localhost:4347" path))]
       (is (= 414 (:status resp))))))
 


### PR DESCRIPTION
Nasty hack to get java.net.URI to support underscore in hostname validation.
Including cherry-pick from main repo.